### PR TITLE
Add basic Jekyll scaffold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '3.1'
+      - name: Install dependencies
+        run: |
+          gem install bundler jekyll
+      - name: Build site
+        run: jekyll build --destination _site
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: _site

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# merulbaddatalks.github.io
+# Merul Badda Talks in Maths and Physics
+
+This repository contains the source for the Merul Badda Talks website. The site is built with [Jekyll](https://jekyllrb.com/) and hosted on GitHub Pages.
+
+## Structure
+
+```
+_merulbadda/         Jekyll layouts, includes, and assets
+  layouts/
+  includes/
+  assets/
+_posts/              Optional blog posts
+/talks/              Markdown files for each talk
+about.md
+upcoming.md
+index.html
+contact.md
+previous-talks.md
+_config.yml
+```
+
+## Adding a New Talk
+
+1. Create a markdown file in the `talks/` directory named `YYYY-MM-DD-slug.md`.
+2. Use the following front matter template:
+
+```yaml
+---
+title: "Talk title"
+date: YYYY-MM-DD
+speaker: "Speaker name"
+affiliation: "Affiliation"
+abstract: >
+  Full abstract text
+speaker_photo: "/assets/images/speakers/NAME.jpg"
+poster_image: "/assets/images/posters/POSTER.jpg"
+youtube_url: "https://www.youtube.com/watch?v=VIDEOID"
+---
+```
+
+3. Commit the file and images to the repository.
+
+## Building Locally
+
+Install Ruby and Jekyll, then run:
+
+```bash
+bundle install # if you use Bundler
+jekyll build --destination _site
+jekyll serve
+```
+
+## Deployment
+
+The workflow in `.github/workflows/ci.yml` builds the site on pushes to `main` and uploads the generated `_site` folder as an artifact. You can adapt it to deploy to GitHub Pages.

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,32 @@
+# Jekyll configuration for Merul Badda Talks
+
+title: "Merul Badda Talks in Maths and Physics"
+email: ""
+description: >- # this means to ignore newlines until ""
+  Seminar series organized by the School of Data and Sciences at BRAC University.
+baseurl: "" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site
+
+timezone: Asia/Dhaka
+
+collections:
+  talks:
+    output: true
+    permalink: /talks/:path/
+
+sass:
+  style: compressed
+
+include:
+  - _merulbadda
+
+defaults:
+  - scope:
+      path: ""
+      type: talks
+    values:
+      layout: talk
+
+permalink: pretty
+
+

--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -1,0 +1,27 @@
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;600&display=swap');
+
+body {
+  font-family: 'Roboto', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+header nav a {
+  margin-right: 1rem;
+}
+
+main {
+  padding: 1rem;
+}
+
+.talk .images {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.talk .speaker-photo,
+.talk .poster-image {
+  max-width: 100%;
+  height: auto;
+}

--- a/_merulbadda/assets/images/posters/bh.jpg
+++ b/_merulbadda/assets/images/posters/bh.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/_merulbadda/assets/images/posters/qfcs.jpg
+++ b/_merulbadda/assets/images/posters/qfcs.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/_merulbadda/assets/images/speakers/ayesha.jpg
+++ b/_merulbadda/assets/images/speakers/ayesha.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/_merulbadda/assets/images/speakers/john.jpg
+++ b/_merulbadda/assets/images/speakers/john.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/_merulbadda/assets/js/main.js
+++ b/_merulbadda/assets/js/main.js
@@ -1,0 +1,2 @@
+// Placeholder for site JavaScript
+console.log('Merul Badda Talks site loaded');

--- a/_merulbadda/includes/footer.html
+++ b/_merulbadda/includes/footer.html
@@ -1,0 +1,3 @@
+<footer>
+  <p>&copy; {{ site.time | date: '%Y' }} Merul Badda Talks. <a href="https://github.com/merulbaddatalks/merulbaddatalks.github.io">GitHub</a></p>
+</footer>

--- a/_merulbadda/includes/header.html
+++ b/_merulbadda/includes/header.html
@@ -1,0 +1,9 @@
+<header>
+  <nav aria-label="Main navigation">
+    <a href="{{ '/' | relative_url }}">Home</a>
+    <a href="{{ '/previous-talks/' | relative_url }}">Previous Talks</a>
+    <a href="{{ '/upcoming/' | relative_url }}">Upcoming Talks</a>
+    <a href="{{ '/about/' | relative_url }}">About</a>
+    <a href="{{ '/contact/' | relative_url }}">Contact</a>
+  </nav>
+</header>

--- a/_merulbadda/layouts/default.html
+++ b/_merulbadda/layouts/default.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }} - {{ site.title }}</title>
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+  </head>
+  <body>
+    {% include header.html %}
+    <main>
+      {{ content }}
+    </main>
+    {% include footer.html %}
+    <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
+  </body>
+</html>

--- a/_merulbadda/layouts/talk.html
+++ b/_merulbadda/layouts/talk.html
@@ -1,0 +1,25 @@
+---
+layout: default
+---
+<article class="talk">
+  <h1>{{ page.title }}</h1>
+  <p class="speaker">{{ page.speaker }}, {{ page.affiliation }}</p>
+  <p class="date">📅 {{ page.date | date: '%B %d, %Y' }}</p>
+  <div class="images">
+    {% if page.speaker_photo %}
+    <img src="{{ page.speaker_photo | relative_url }}" alt="{{ page.speaker }}" class="speaker-photo"/>
+    {% endif %}
+    {% if page.poster_image %}
+    <img src="{{ page.poster_image | relative_url }}" alt="Poster for {{ page.title }}" class="poster-image"/>
+    {% endif %}
+  </div>
+  <section class="abstract">
+    <h2>Abstract</h2>
+    {{ page.abstract }}
+  </section>
+  {% if page.youtube_url %}
+  <div class="video">
+    <iframe width="560" height="315" src="{{ page.youtube_url | replace: 'watch?v=', 'embed/' }}" frameborder="0" allowfullscreen></iframe>
+  </div>
+  {% endif %}
+</article>

--- a/about.md
+++ b/about.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: "About"
+---
+
+## About Merul Badda Talks
+
+The Merul Badda Talks in Maths and Physics is a seminar series hosted by the School of Data and Sciences at BRAC University.

--- a/contact.md
+++ b/contact.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: "Contact"
+---
+
+Please contact us at <a href="mailto:info@bracu.ac.bd">info@bracu.ac.bd</a>.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: "Home"
+---
+<h1>{{ site.title }}</h1>
+<p>Seminar series organized by the School of Data and Sciences, BRAC University.</p>
+<p><a href="{{ '/upcoming/' | relative_url }}">View upcoming talks</a></p>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "merulbaddatalks",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "jekyll build --destination _site",
+    "serve": "jekyll serve",
+    "deploy": "gh-pages -d _site"
+  },
+  "devDependencies": {
+  }
+}

--- a/previous-talks.md
+++ b/previous-talks.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: "Previous Talks"
+---
+
+<h2>Previous Talks</h2>
+<ul>
+  {% assign past = site.talks | where_exp: 'talk', 'talk.date <= site.time' | sort: 'date' | reverse %}
+  {% for talk in past %}
+  <li>{{ talk.date | date: '%B %d, %Y' }} - <a href="{{ talk.url }}">{{ talk.title }}</a></li>
+  {% endfor %}
+</ul>

--- a/talks/2023-09-05-xyz.md
+++ b/talks/2023-09-05-xyz.md
@@ -1,0 +1,11 @@
+---
+title: "Quantum Fields on Curved Spaces"
+date: 2023-09-05
+speaker: "Dr. Ayesha Khan"
+affiliation: "BRAC University"
+abstract: >
+  An introductory talk on quantizing fields in curved spacetime.
+speaker_photo: "/assets/images/speakers/ayesha.jpg"
+poster_image: "/assets/images/posters/qfcs.jpg"
+youtube_url: "https://www.youtube.com/watch?v=XXXXXXXXX"
+---

--- a/talks/2024-02-14-abc.md
+++ b/talks/2024-02-14-abc.md
@@ -1,0 +1,11 @@
+---
+title: "Black Holes and Information"
+date: 2024-02-14
+speaker: "Prof. John Doe"
+affiliation: "Some University"
+abstract: >
+  Discussing the information paradox and recent progress.
+speaker_photo: "/assets/images/speakers/john.jpg"
+poster_image: "/assets/images/posters/bh.jpg"
+youtube_url: "https://www.youtube.com/watch?v=YYYYYYYYY"
+---

--- a/upcoming.md
+++ b/upcoming.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: "Upcoming Talks"
+---
+
+<h2>Upcoming Talks</h2>
+<ul>
+  {% assign upcoming = site.talks | where_exp: 'talk', 'talk.date > site.time' | sort: 'date' %}
+  {% for talk in upcoming %}
+  <li>{{ talk.date | date: '%B %d, %Y' }} - <a href="{{ talk.url }}">{{ talk.title }}</a></li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- set up initial Jekyll structure with layouts, includes and assets
- add pages for index, about, contact, upcoming and previous talks
- include example talk markdown files
- add basic GitHub Actions workflow
- document usage and structure in README

## Testing
- `jekyll build --destination _site` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684650b89920832eb166eb3bb2e7e479