### PR TITLE
Fix Jekyll directory settings

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,12 @@ collections:
     output: true
     permalink: /talks/:path/
 
+layouts_dir: _merulbadda/layouts
+includes_dir: _merulbadda/includes
+
 sass:
+  sass_dir: _merulbadda/assets/css
+  css_dir: assets/css
   style: compressed
 
 include:


### PR DESCRIPTION
## Summary
- fix missing layout/include paths so Jekyll can find the templates
- configure SCSS input/output directories

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846559ea5cc832ea41d8186abf02d83