### PR TITLE
Fix upcoming talk visibility and layout tweaks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,5 +33,6 @@ defaults:
       layout: talk
 
 permalink: pretty
+future: true
 
 

--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -22,27 +22,29 @@ body {
 header {
   background: $primary;
   padding: 1rem;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 header .logo img {
-  display: block;
-  margin: 0 auto;
   height: 150px;
-
 }
 
 header nav {
-  margin-top: 0.5rem;
   display: flex;
   gap: 1rem;
-  justify-content: center;
 }
 
 header nav a {
   color: #fff;
   text-decoration: none;
   font-weight: 600;
+}
+
+header nav a:active,
+footer a:active {
+  color: #A8DADC;
 }
 
 header nav a:hover {

--- a/_merulbadda/layouts/talk.html
+++ b/_merulbadda/layouts/talk.html
@@ -3,9 +3,6 @@ layout: default
 ---
 <article class="talk">
   <div class="talk-header">
-    {% if page.speaker_photo %}
-    <img src="{{ page.speaker_photo | relative_url }}" alt="{{ page.speaker }}" class="speaker-photo" />
-    {% endif %}
     <div class="talk-meta">
       <h1>{{ page.title | markdownify }}</h1>
 
@@ -19,6 +16,9 @@ layout: default
         {% endif %}
       </p>
     </div>
+    {% if page.speaker_photo %}
+    <img src="{{ page.speaker_photo | relative_url }}" alt="{{ page.speaker }}" class="speaker-photo" />
+    {% endif %}
   </div>
   <section class="abstract">
     <h2>Abstract</h2>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,19 +22,16 @@ body {
 header {
   background: var(--primary);
   padding: 1rem;
-  text-align: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 header .logo img {
-  display: block;
-  margin: 0 auto;
   height: 150px;
-
 }
 header nav {
-  margin-top: 0.5rem;
   display: flex;
   gap: 1rem;
-  justify-content: center;
 }
 header nav a {
   color: #fff;
@@ -58,6 +55,11 @@ footer {
 }
 footer a {
   color: #fff;
+}
+a:active,
+footer a:active,
+header nav a:active {
+  color: #A8DADC;
 }
 a {
   color: var(--primary);


### PR DESCRIPTION
## Summary
- allow building future-dated talks
- update talk page layout to place text left and photo right
- adjust header layout and add active link color
- update compiled CSS

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden due to lack of internet access)*

------
https://chatgpt.com/codex/tasks/task_e_684bc20fd3e0832e8e63b5ce5a1f2b0c