### PR TITLE
Improve header and talk spacing

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -21,10 +21,11 @@ body {
 
 header {
   background: $primary;
-  padding: 1rem;
+  padding: 1rem 2rem;
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
+  gap: 2rem;
 }
 
 header .logo img {
@@ -88,8 +89,8 @@ a:hover {
 .talk-header {
   display: flex;
   flex-direction: row;
-
   align-items: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 
@@ -103,12 +104,21 @@ a:hover {
   margin: 0;
 }
 
+.talk-header h1 {
+  margin-bottom: 0.25rem;
+}
+
+.talk-header .speaker {
+  margin-bottom: 0.25rem;
+}
+
 
 .talk .speaker-photo {
   width: 150px;
   height: 150px;
   object-fit: cover;
   border: 3px solid $primary;
+  margin-left: auto;
 
 }
 


### PR DESCRIPTION
## Summary
- tune header layout to keep logo and menu centered
- tweak talk header spacing and photo alignment

## Testing
- `bundle exec jekyll build --destination _site` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_684bc4fded54832ebca81b1c3c0df7fb