### PR TITLE
Improve mobile styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -129,3 +129,29 @@ a:hover {
   color: #000;
   font-weight: bold;
 }
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+  }
+  header .logo img {
+    height: 100px;
+  }
+  header nav {
+    flex-direction: column;
+    width: 100%;
+    align-items: flex-start;
+  }
+  header nav a {
+    padding: 0.5rem 0;
+  }
+  .talk-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .talk .speaker-photo {
+    width: 100%;
+    max-width: 200px;
+  }
+}


### PR DESCRIPTION
## Summary
- add media query to style header and talk layout for narrow screens

## Testing
- `bundle exec jekyll build --destination _site` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684be12e8d94832e84a6013ab5483c36