### PR TITLE
Update upcoming talk card style

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -117,6 +117,14 @@ a:hover {
   margin-bottom: 0.25rem;
 }
 
+.talk-header .affiliation {
+  margin-bottom: 0.5rem;
+}
+
+.talk-header .date {
+  margin-top: 0.5rem;
+}
+
 
 .talk .speaker-photo {
   width: 150px;
@@ -170,7 +178,8 @@ a:hover {
 }
 
 .upcoming-talk {
-  background: $highlight;
+  background: $text;
+  color: $highlight;
   padding: 1rem;
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -179,6 +188,14 @@ a:hover {
   text-align: center;
   border: 2px solid $primary;
 
+}
+
+.upcoming-talk a {
+  color: $highlight;
+}
+
+.upcoming-talk a:hover {
+  text-decoration: underline;
 }
 
 .upcoming-talk h2 {

--- a/index.html
+++ b/index.html
@@ -10,9 +10,9 @@ title: "Home"
   {% if next %}
     <p class="next-talk"><strong>{{ next.date | date: '%B %d, %Y' }}:</strong>
 
-    {{ next.title }} (<a href="{{ next.url | relative_url }}">view abstract</a>)<br>
+    {{ next.title }}<br>
 
-    {{ next.speaker }}, {{ next.affiliation }}</p>
+    {{ next.speaker }}, {{ next.affiliation }} (<a href="{{ next.url | relative_url }}">view abstract</a>)</p>
     {% if next.room %}<p>Room: {{ next.room }} | <a href="{{ next.rsvp }}">RSVP</a></p>{% endif %}
     <div id="upcoming-calendar" data-date="{{ next.date }}"></div>
   {% else %}


### PR DESCRIPTION
## Summary
- swap background and text colors for upcoming talk card and ensure link is visible
- move "view abstract" link next to affiliation on the home page
- add spacing around affiliation and date on talk pages

## Testing
- `npm run build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684beb01d7d0832e810102c5339d2f83