### PR TITLE
Add time support for upcoming talks

### DIFF
--- a/_merulbadda/layouts/talk.html
+++ b/_merulbadda/layouts/talk.html
@@ -11,6 +11,7 @@ layout: default
 
       <p class="date">📅 {{ page.date | date: '%B %d, %Y' }}
         {% if page.date >= site.time %}
+          {% if page.time %} | Time: {{ page.time }}{% endif %}
           {% if page.room %} | Room: {{ page.room }}{% endif %}
           {% if page.rsvp %} | <a href="{{ page.rsvp }}">RSVP</a>{% endif %}
         {% endif %}

--- a/_talks/2025-06-19-amin.md
+++ b/_talks/2025-06-19-amin.md
@@ -3,7 +3,8 @@ title: "A spin on dark matter"
 date: 2025-06-19
 speaker: "Dr Mustafa Amin"
 affiliation: "Associate Professor, Physics and Astronomy, Rice University, USA"
-room: "TBA"
+room: "09C-16T"
+time: "5pm"
 rsvp: "https://forms.gle/WXQiQJPo8GdvfqmS7"
 abstract: >
   Dark matter makes up >80% of nonrelativistic matter in our cosmos,

--- a/index.html
+++ b/index.html
@@ -14,7 +14,13 @@ title: "Home"
 
     {{ next.speaker }}, {{ next.affiliation }}<br>
     <a href="{{ next.url | relative_url }}">view abstract</a></p>
-    {% if next.room %}<p>Room: {{ next.room }} | <a href="{{ next.rsvp }}">RSVP</a></p>{% endif %}
+    {% if next.time or next.room or next.rsvp %}
+    <p>
+      {% if next.time %}Time: {{ next.time }}{% endif %}
+      {% if next.room %}{% if next.time %} | {% endif %}Room: {{ next.room }}{% endif %}
+      {% if next.rsvp %} | <a href="{{ next.rsvp }}">RSVP</a>{% endif %}
+    </p>
+    {% endif %}
     <div id="upcoming-calendar" data-date="{{ next.date }}"></div>
   {% else %}
     <p>No upcoming talks scheduled.</p>

--- a/upcoming.md
+++ b/upcoming.md
@@ -12,6 +12,7 @@ permalink: /upcoming/
   <li>{{ talk.date | date: '%B %d, %Y' }} - {{ talk.title }}
   (<a href="{{ talk.url | relative_url }}">view abstract</a>)
 
+  {% if talk.time %}(Time: {{ talk.time }}){% endif %}
   {% if talk.room %}(Room: {{ talk.room }}){% endif %}
   {% if talk.rsvp %}<a href="{{ talk.rsvp }}">RSVP</a>{% endif %}</li>
   {% endfor %}


### PR DESCRIPTION
## Summary
- show time for upcoming talks in talk layout and home
- display time in upcoming talks page
- set time & room for Mustafa Amin talk

## Testing
- `bundle exec jekyll build` *(fails: bundler can't install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684fe5d17574832eb1d1772b7d9eed89