### PR TITLE
Update homepage upcoming talk layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -152,7 +152,7 @@ a:hover {
 
   margin: 1rem auto 2rem;
   max-width: 600px;
-  text-align: center;
+  text-align: left;
   border: 2px solid var(--primary);
 
 }
@@ -162,9 +162,26 @@ a:hover {
 .upcoming-talk h2 {
   margin-top: 0;
 }
-.upcoming-talk .next-talk {
-  font-size: 1.1rem;
-  margin-bottom: 1rem;
+.upcoming-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.upcoming-item {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 0.75rem;
+}
+.upcoming-date {
+  font-weight: bold;
+  margin-right: 1rem;
+  white-space: nowrap;
+}
+.upcoming-details .affiliation {
+  font-size: 0.9rem;
+}
+.upcoming-details .meta {
+  font-size: 0.9rem;
 }
 @media (max-width: 600px) {
   header {
@@ -215,9 +232,5 @@ a:hover {
   .upcoming-talk {
     max-width: 100%;
     padding: 0.75rem;
-  }
-
-  .upcoming-talk .next-talk {
-    font-size: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -4,24 +4,26 @@ title: "Home"
 ---
 
 {% assign upcoming = site.talks | where_exp: 't','t.date >= site.time' | sort: 'date' %}
-{% assign next = upcoming[0] %}
 <section class="upcoming-talk">
-  <h2>Upcoming Talk</h2>
-  {% if next %}
-    <p class="next-talk"><strong>{{ next.date | date: '%B %d, %Y' }}:</strong>
-
-    {{ next.title }}<br>
-
-    {{ next.speaker }}, {{ next.affiliation }}<br>
-    <a href="{{ next.url | relative_url }}">view abstract</a></p>
-    {% if next.time or next.room or next.rsvp %}
-    <p>
-      {% if next.time %}Time: {{ next.time }}{% endif %}
-      {% if next.room %}{% if next.time %} | {% endif %}Room: {{ next.room }}{% endif %}
-      {% if next.rsvp %} | <a href="{{ next.rsvp }}">RSVP</a>{% endif %}
-    </p>
-    {% endif %}
-    <div id="upcoming-calendar" data-date="{{ next.date }}"></div>
+  <h2>Upcoming Talks</h2>
+  {% if upcoming != empty %}
+  <ul class="upcoming-list">
+    {% for talk in upcoming %}
+    <li class="upcoming-item">
+      <span class="upcoming-date">{{ talk.date | date: '%B %d, %Y' }}.</span>
+      <div class="upcoming-details">
+        <span class="title"><a href="{{ talk.url | relative_url }}">{{ talk.title }}</a></span><br>
+        <span class="speaker">{{ talk.speaker }}</span><br>
+        <span class="affiliation">{{ talk.affiliation }}</span><br>
+        <span class="meta">
+          {% if talk.time %}{{ talk.time }}{% endif %}
+          {% if talk.room %}{% if talk.time %} | {% endif %}Room: {{ talk.room }}{% endif %}
+          {% if talk.rsvp %} | <a href="{{ talk.rsvp }}">RSVP</a>{% endif %}
+        </span>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
   {% else %}
     <p>No upcoming talks scheduled.</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- redesign upcoming talks on the home page to list all upcoming events
- adjust CSS for new layout with smaller affiliation text

## Testing
- `bundle exec jekyll build --destination _site` *(fails: jekyll missing)*
- `bundle install` *(fails: blocked from fetching rubygems)*

------
https://chatgpt.com/codex/tasks/task_e_684fe78d6cb0832e9f25e6e236b86e41