### PR TITLE
Improve upcoming talks styling

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -7,6 +7,10 @@ $bg: #A8DADC; // body background
 $text: #457B9D; // Text color on light background
 $highlight: #F1FAEE;
 
+.page-title {
+  text-align: center;
+}
+
 
 body {
   font-family: 'Roboto Mono', monospace;
@@ -196,10 +200,17 @@ a:hover {
 
 .upcoming-talk a:hover {
   text-decoration: underline;
+  color: $accent;
+}
+
+.upcoming-talk:hover,
+.upcoming-talk:focus-within {
+  box-shadow: 0 0 0 3px $accent;
 }
 
 .upcoming-talk h2 {
   margin-top: 0;
+  text-align: center;
 }
 
 .upcoming-talk .next-talk {
@@ -234,6 +245,10 @@ a:hover {
 .upcoming-details .title {
   font-size: 1.1rem;
   font-weight: 600;
+}
+
+.upcoming-details .meta {
+  font-size: 1.1rem;
 }
 
 @media (max-width: 600px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,6 +9,10 @@
 
   --primary-dark: #003961;
 }
+
+.page-title {
+  text-align: center;
+}
 body {
   font-family: 'Roboto Mono', monospace;
   margin: 0;
@@ -159,8 +163,17 @@ a:hover {
 .upcoming-talk a {
   color: #f1faee;
 }
+.upcoming-talk a:hover {
+  text-decoration: underline;
+  color: #F0B7A4;
+}
+.upcoming-talk:hover,
+.upcoming-talk:focus-within {
+  box-shadow: 0 0 0 3px #F0B7A4;
+}
 .upcoming-talk h2 {
   margin-top: 0;
+  text-align: center;
 }
 .upcoming-list {
   list-style: none;
@@ -190,7 +203,7 @@ a:hover {
   font-size: 0.9rem;
 }
 .upcoming-details .meta {
-  font-size: 0.9rem;
+  font-size: 1.1rem;
 }
 @media (max-width: 600px) {
   header {

--- a/upcoming.md
+++ b/upcoming.md
@@ -4,7 +4,7 @@ title: "Upcoming Talks"
 permalink: /upcoming/
 ---
 
-<h2>Upcoming Talks</h2>
+<h2 class="page-title">Upcoming Talks</h2>
 <ul>
   {% assign upcoming = site.talks | where_exp: 'talk', 'talk.date > site.time' | sort: 'date' %}
   {% for talk in upcoming %}


### PR DESCRIPTION
## Summary
- center the upcoming talks page title
- highlight upcoming cards and links
- enlarge meta info font size

## Testing
- `bundle exec jekyll build --quiet` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fecae8c6c832e817f7014e4537dd2