### PR TITLE
Fix mobile width overflow

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -7,6 +7,15 @@ $bg: #A8DADC; // body background
 $text: #457B9D; // Text color on light background
 $highlight: #F1FAEE;
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .page-title {
   text-align: center;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -10,6 +10,15 @@
   --primary-dark: #003961;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
 .page-title {
   text-align: center;
 }


### PR DESCRIPTION
## Summary
- ensure padding doesn't cause overflow on small screens
- make images responsive

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502d739b6c832e9da5f6d07cf7fe6f