### PR TITLE
Improve mobile homepage layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -264,4 +264,44 @@ a:hover {
     max-width: 100%;
     padding: 0.75rem;
   }
+
+  /* Stack upcoming talk details vertically */
+  .upcoming-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .upcoming-date {
+    margin-right: 0;
+    margin-bottom: 0.25rem;
+    min-width: auto;
+  }
+
+  /* Convert previous talks table to card layout */
+  .talk-table {
+    display: block;
+    border: none;
+  }
+  .talk-table thead {
+    display: none;
+  }
+  .talk-table tr {
+    display: block;
+    border: 1px solid #444;
+    margin-bottom: 1rem;
+    padding: 0.5rem;
+  }
+  .talk-table td {
+    display: block;
+    border: none;
+    text-align: left;
+    padding: 0.25rem 0;
+    font-size: 0.9rem;
+  }
+  .talk-table td::before {
+    content: attr(data-label);
+    font-weight: bold;
+    display: inline-block;
+    width: 45%;
+    margin-right: 0.5rem;
+  }
 }

--- a/index.html
+++ b/index.html
@@ -39,12 +39,12 @@ title: "Home"
       {% assign past = site.talks | where_exp: 't','t.date < site.time' | sort:'date' | reverse %}
       {% for talk in past limit:5 %}
       <tr>
-        <td>{{ talk.date | date: '%Y-%m-%d' }}</td>
-        <td><a href="{{ talk.url | relative_url }}">{{ talk.title }}</a></td>
-        <td>{{ talk.speaker }}</td>
-        <td>{{ talk.affiliation }}</td>
-        <td>{% if talk.youtube_url %}<a href="{{ talk.youtube_url }}">Video</a>{% else %}N/A{% endif %}</td>
-        <td>{% if talk.slides_url %}<a href="{{ talk.slides_url }}">Slides</a>{% else %}N/A{% endif %}</td>
+        <td data-label="Date">{{ talk.date | date: '%Y-%m-%d' }}</td>
+        <td data-label="Title"><a href="{{ talk.url | relative_url }}">{{ talk.title }}</a></td>
+        <td data-label="Speaker">{{ talk.speaker }}</td>
+        <td data-label="Affiliation">{{ talk.affiliation }}</td>
+        <td data-label="Recording">{% if talk.youtube_url %}<a href="{{ talk.youtube_url }}">Video</a>{% else %}N/A{% endif %}</td>
+        <td data-label="Slides">{% if talk.slides_url %}<a href="{{ talk.slides_url }}">Slides</a>{% else %}N/A{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- stack upcoming talk details vertically on small screens
- convert previous talks table into mobile-friendly cards
- add data labels to table cells for accessibility

## Testing
- `npm run build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68502f6152d8832e8f21a642b330f37b