### PR TITLE
Fix mobile overflow

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -11,6 +11,10 @@ $highlight: #F1FAEE;
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 img {
   max-width: 100%;
   height: auto;
@@ -30,6 +34,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 header {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -14,6 +14,10 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+}
+
 img {
   max-width: 100%;
   height: auto;
@@ -31,6 +35,7 @@ body {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  overflow-x: hidden;
 }
 header {
   background: var(--primary);


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling on mobile by hiding horizontal overflow on html and body

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68503131f038832e9fb6c759c9c4bae9