### PR TITLE
Fix mobile card layout for previous talks

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -409,8 +409,8 @@ a:hover {
     font-size: 1rem;
   }
 }
-// ### START MOBILE OVERRIDES ###
-// Place this block at the end of your existing stylesheet:
+/* ### START MOBILE OVERRIDES ### */
+/* Place this block at the end of your existing stylesheet: */
 
 @media screen and (max-width: 640px) {
 
@@ -488,4 +488,4 @@ a:hover {
   }
 }
 
-// ### END MOBILE OVERRIDES ###
+/* ### END MOBILE OVERRIDES ### */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -406,8 +406,8 @@ a:hover {
     margin-right: 0.5rem;
   }
 }
-// ### START MOBILE OVERRIDES ###
-// Place this block at the end of your existing stylesheet:
+/* ### START MOBILE OVERRIDES ### */
+/* Place this block at the end of your existing stylesheet: */
 
 @media screen and (max-width: 640px) {
 
@@ -489,4 +489,4 @@ a:hover {
   }
 }
 
-// ### END MOBILE OVERRIDES ###
+/* ### END MOBILE OVERRIDES ### */


### PR DESCRIPTION
## Summary
- make mobile overrides valid CSS so previous talks show as cards

## Testing
- `npm run build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68506f237898832eb11ef91bfbc37550