### PR TITLE
Fix layout width and sticky footer

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -42,6 +42,9 @@ body {
   padding-right: 1rem;
   margin: 0 auto;
   max-width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 header {
   background: var(--primary);
@@ -131,10 +134,11 @@ header .site-nav a {
   color: #457b9d;
 }
 main {
-  max-width: 960px;
+  max-width: 100%;
   margin: 0 auto;
   padding: 1rem;
   flex: 1;
+  width: 100%;
 }
 footer {
   background: var(--primary);


### PR DESCRIPTION
## Summary
- make main container a flex layout so footer stays at the bottom
- allow main content to span full width

## Testing
- `npm run build` *(fails: jekyll not installed)*
- `bundle install` *(fails: unable to fetch gems)*

------
https://chatgpt.com/codex/tasks/task_e_6850702d0ed8832e835f6980b5f70f80