### PR TITLE
Adjust layout widths and talk page styling

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -51,6 +51,7 @@ header {
   justify-content: center;
   align-items: center;
   gap: 2rem;
+  width: 100%;
 }
 
 header .logo img {
@@ -147,6 +148,7 @@ footer {
   color: #fff;
   text-align: center;
   padding: 0.5rem 1rem;
+  width: 100%;
 }
 
 footer a {
@@ -193,18 +195,26 @@ a:hover {
 
 .talk-header h1 {
   margin-bottom: 1rem;
+  font-size: 2rem;
 }
 
 .talk-header .speaker {
   margin-bottom: 0.5rem;
+  font-size: 1.25rem;
 }
 
 .talk-header .affiliation {
   margin-bottom: 0.5rem;
+  font-size: 1.25rem;
 }
 
 .talk-header .date {
   margin-top: 0.5rem;
+}
+
+.talk {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 
@@ -360,12 +370,13 @@ a:hover {
     justify-content: space-between;
   }
   header .logo img {
-    height: 100px;
+    height: 80px;
   }
   header .site-nav .nav-list {
     flex-direction: column;
     width: auto;
     align-items: flex-end;
+    text-align: right;
   }
   header .site-nav a {
     padding: 0.25rem 0;
@@ -425,6 +436,16 @@ a:hover {
   }
   .previous-talks-cards {
     display: block;
+  }
+
+  // Remove styling on previous talk cards in mobile view
+  .previous-talks-cards .talk-card {
+    background: none;
+    border: none;
+    color: inherit;
+  }
+  .previous-talks-cards .talk-card a {
+    color: $text;
   }
 
   /* 2. Collapse upcoming talk layout into a vertical card */

--- a/_merulbadda/layouts/default.html
+++ b/_merulbadda/layouts/default.html
@@ -22,13 +22,13 @@
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
   </head>
   <body>
+    {% include header.html %}
     <div class="container">
-      {% include header.html %}
       <main>
         {{ content }}
       </main>
-      {% include footer.html %}
     </div>
+    {% include footer.html %}
     <script src="{{ '/assets/js/main.js' | relative_url }}"></script>
   </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -42,9 +42,6 @@ body {
   padding-right: 1rem;
   margin: 0 auto;
   max-width: 100%;
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
 }
 header {
   background: var(--primary);
@@ -52,6 +49,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  width: 100%;
 }
 header .logo img {
   height: 150px;
@@ -134,17 +132,17 @@ header .site-nav a {
   color: #457b9d;
 }
 main {
-  max-width: 100%;
+  max-width: 960px;
   margin: 0 auto;
   padding: 1rem;
   flex: 1;
-  width: 100%;
 }
 footer {
   background: var(--primary);
   color: #fff;
   text-align: center;
   padding: 0.5rem 1rem;
+  width: 100%;
 }
 footer a {
   color: #fff;
@@ -184,12 +182,23 @@ a:hover {
 }
 .talk-header h1 {
   margin-bottom: 1rem;
+  font-size: 2rem;
 }
 .talk-header .speaker {
   margin-bottom: 0.5rem;
+  font-size: 1.25rem;
+}
+.talk-header .affiliation {
+  margin-bottom: 0.5rem;
+  font-size: 1.25rem;
 }
 .talk-header .date {
   margin-top: 0.5rem;
+}
+
+.talk {
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .talk .speaker-photo {
@@ -325,12 +334,13 @@ a:hover {
     justify-content: space-between;
   }
   header .logo img {
-    height: 100px;
+    height: 80px;
   }
   header .site-nav .nav-list {
     flex-direction: column;
     width: auto;
     align-items: flex-end;
+    text-align: right;
   }
   header .site-nav a {
     padding: 0.25rem 0;
@@ -426,6 +436,16 @@ a:hover {
   }
   .previous-talks-cards {
     display: block;
+  }
+
+  /* Remove styling on previous talk cards in mobile view */
+  .previous-talks-cards .talk-card {
+    background: none;
+    border: none;
+    color: inherit;
+  }
+  .previous-talks-cards .talk-card a {
+    color: var(--text);
   }
 
   /* 2. Collapse upcoming talk layout into a vertical card */


### PR DESCRIPTION
## Summary
- make header/footer full width by moving them outside the container
- keep main content narrow again
- enlarge talk titles and speaker info
- add padding to talk pages
- tweak mobile header logo size and right-align menu
- update compiled CSS

## Testing
- `npm run build` *(fails: jekyll missing)*
- `bundle install` *(fails: network access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850722a9090832eb3e1c560ae589fa2