### PR TITLE
Adjust layout styles for footer and talks

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -42,6 +42,7 @@ body {
   padding-right: 1rem;
   margin: 0 auto;
   max-width: 100%;
+  flex: 1;
 }
 
 header {
@@ -195,7 +196,8 @@ a:hover {
 
 .talk-header h1 {
   margin-bottom: 1rem;
-  font-size: 2rem;
+  font-size: 2.5rem;
+  font-weight: bold;
 }
 
 .talk-header .speaker {
@@ -210,6 +212,7 @@ a:hover {
 
 .talk-header .date {
   margin-top: 0.5rem;
+  font-size: 1.25rem;
 }
 
 .talk {
@@ -222,6 +225,7 @@ a:hover {
   width: 150px;
   height: 150px;
   object-fit: cover;
+  aspect-ratio: 1 / 1;
   border: 3px solid $primary;
   margin-left: auto;
 
@@ -353,6 +357,12 @@ a:hover {
   margin-bottom: 1rem;
   border: 2px solid $primary;
 }
+.previous-talks-cards .talk-date,
+.previous-talks-cards .talk-title,
+.previous-talks-cards .talk-speaker,
+.previous-talks-cards .talk-affiliation {
+  margin-bottom: 0.25rem;
+}
 
 .previous-talks-cards .talk-card a {
   color: $highlight;
@@ -370,7 +380,7 @@ a:hover {
     justify-content: space-between;
   }
   header .logo img {
-    height: 80px;
+    height: 75px;
   }
   header .site-nav .nav-list {
     flex-direction: column;
@@ -389,6 +399,7 @@ a:hover {
   .talk .speaker-photo {
     width: 100%;
     max-width: 200px;
+    aspect-ratio: 1 / 1;
   }
   .talk-table,
   .calendar-table {
@@ -398,7 +409,7 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 
   .talk-header p {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -42,6 +42,7 @@ body {
   padding-right: 1rem;
   margin: 0 auto;
   max-width: 100%;
+  flex: 1;
 }
 header {
   background: var(--primary);
@@ -182,7 +183,8 @@ a:hover {
 }
 .talk-header h1 {
   margin-bottom: 1rem;
-  font-size: 2rem;
+  font-size: 2.5rem;
+  font-weight: bold;
 }
 .talk-header .speaker {
   margin-bottom: 0.5rem;
@@ -194,6 +196,7 @@ a:hover {
 }
 .talk-header .date {
   margin-top: 0.5rem;
+  font-size: 1.25rem;
 }
 
 .talk {
@@ -205,6 +208,7 @@ a:hover {
   width: 150px;
   height: 150px;
   object-fit: cover;
+  aspect-ratio: 1 / 1;
   border: 3px solid var(--primary);
 
 }
@@ -318,6 +322,12 @@ a:hover {
   margin-bottom: 1rem;
   border: 2px solid var(--primary);
 }
+.previous-talks-cards .talk-date,
+.previous-talks-cards .talk-title,
+.previous-talks-cards .talk-speaker,
+.previous-talks-cards .talk-affiliation {
+  margin-bottom: 0.25rem;
+}
 
 .previous-talks-cards .talk-card a {
   color: #f1faee;
@@ -334,7 +344,7 @@ a:hover {
     justify-content: space-between;
   }
   header .logo img {
-    height: 80px;
+    height: 75px;
   }
   header .site-nav .nav-list {
     flex-direction: column;
@@ -353,6 +363,7 @@ a:hover {
   .talk .speaker-photo {
     width: 100%;
     max-width: 200px;
+    aspect-ratio: 1 / 1;
   }
   .talk-table,
   .calendar-table {
@@ -362,7 +373,7 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
   }
 
   .talk-header p {

--- a/previous-talks.md
+++ b/previous-talks.md
@@ -28,8 +28,9 @@ title: "Previous Talks"
   {% for talk in past %}
   <div class="talk-card">
     <div class="talk-date">{{ talk.date | date: '%B %d, %Y' }}</div>
-    <div class="talk-title">{{ talk.title }}</div>
-    <div class="talk-speaker">{{ talk.speaker }}{% if talk.affiliation %} ({{ talk.affiliation }}){% endif %}</div>
+    <div class="talk-title"><a href="{{ talk.url | relative_url }}">{{ talk.title }}</a></div>
+    <div class="talk-speaker">{{ talk.speaker }}</div>
+    {% if talk.affiliation %}<div class="talk-affiliation">{{ talk.affiliation }}</div>{% endif %}
     <div class="talk-links">
       {% if talk.youtube_url %}<a href="{{ talk.youtube_url }}">Video</a>{% endif %}
       {% if talk.slides_url %}{% if talk.youtube_url %} | {% endif %}<a href="{{ talk.slides_url }}">Slides</a>{% endif %}


### PR DESCRIPTION
## Summary
- make container flexible so footer stays at bottom
- shrink mobile header logo and enlarge talk page typography
- ensure speaker images stay square
- add spacing to previous talks cards and link titles

## Testing
- `bundle exec jekyll build` *(fails: bundler not installed)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6850d41716ec832eaccd9e668d4f433d