### PR TITLE
Improve mobile talk header typography

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -409,11 +409,13 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 1.5rem;
+    font-size: 2rem;
   }
 
-  .talk-header p {
-    font-size: 0.9rem;
+  .talk-header .speaker,
+  .talk-header .affiliation,
+  .talk-header .date {
+    font-size: 0.8rem;
   }
 
   .talk-table th,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -373,11 +373,13 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 1.5rem;
+    font-size: 2rem;
   }
 
-  .talk-header p {
-    font-size: 0.9rem;
+  .talk-header .speaker,
+  .talk-header .affiliation,
+  .talk-header .date {
+    font-size: 0.8rem;
   }
 
   .talk-table th,


### PR DESCRIPTION
## Summary
- enlarge talk heading on mobile
- shrink metadata fonts

## Testing
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6850d7f69d70832eb88ce61ee5dc5446