### PR TITLE
Add media coverage titles

### DIFF
--- a/_merulbadda/assets/js/main.js
+++ b/_merulbadda/assets/js/main.js
@@ -31,4 +31,81 @@ document.addEventListener('DOMContentLoaded', () => {
       menu.classList.toggle('open');
     });
   }
+
+  fetch('/talks.json')
+    .then(r => r.json())
+    .then(talks => {
+      const now = new Date();
+      talks.sort((a, b) => new Date(a.date) - new Date(b.date));
+      const upcoming = [];
+      const past = [];
+      talks.forEach(t => {
+        const endOfDay = new Date(t.date + 'T23:59:59');
+        if (endOfDay >= now) {
+          upcoming.push(t);
+        } else {
+          past.push(t);
+        }
+      });
+      past.reverse();
+
+      const upcomingList = document.querySelector('.upcoming-list');
+      if (upcomingList) {
+        upcomingList.innerHTML = '';
+        upcoming.forEach(t => {
+          const li = document.createElement('li');
+          const dateStr = new Date(t.date).toLocaleDateString('en-US', { year:'numeric', month:'long', day:'2-digit' });
+          let html = `${dateStr} - <a href="${t.url}">${t.title}</a>`;
+          if (t.time) html += ` (Time: ${t.time})`;
+          if (t.room) html += ` (Room: ${t.room})`;
+          if (t.rsvp) html += ` <a href="${t.rsvp}">RSVP</a>`;
+          li.innerHTML = html;
+          upcomingList.appendChild(li);
+        });
+        if (upcoming.length === 0) {
+          const p = document.createElement('p');
+          p.textContent = 'No upcoming talks scheduled.';
+          upcomingList.parentNode.insertBefore(p, upcomingList);
+          upcomingList.remove();
+        }
+      }
+
+      const pastBody = document.querySelector('.previous-talks-table tbody');
+      if (pastBody) {
+        pastBody.innerHTML = '';
+        past.forEach(t => {
+          const tr = document.createElement('tr');
+          const dateShort = new Date(t.date).toISOString().slice(0,10);
+          tr.innerHTML = `
+            <td data-label="Date">${dateShort}</td>
+            <td data-label="Title"><a href="${t.url}">${t.title}</a></td>
+            <td data-label="Speaker">${t.speaker}</td>
+            <td data-label="Affiliation">${t.affiliation || ''}</td>
+            <td data-label="Recording">${t.youtube_url ? `<a href="${t.youtube_url}">Video</a>` : 'N/A'}</td>
+            <td data-label="Slides">${t.slides_url ? `<a href="${t.slides_url}">Slides</a>` : 'N/A'}</td>`;
+          pastBody.appendChild(tr);
+        });
+      }
+
+      const pastCards = document.querySelector('.previous-talks-cards');
+      if (pastCards) {
+        pastCards.innerHTML = '';
+        past.forEach(t => {
+          const div = document.createElement('div');
+          div.className = 'talk-card';
+          const dateStr = new Date(t.date).toLocaleDateString('en-US', { year:'numeric', month:'long', day:'2-digit' });
+          const links = [];
+          if (t.youtube_url) links.push(`<a href="${t.youtube_url}">Video</a>`);
+          if (t.slides_url) links.push(`<a href="${t.slides_url}">Slides</a>`);
+          div.innerHTML = `
+            <div class="talk-date">${dateStr}</div>
+            <div class="talk-title"><a href="${t.url}">${t.title}</a></div>
+            <div class="talk-speaker">${t.speaker}</div>
+            ${t.affiliation ? `<div class="talk-affiliation">${t.affiliation}</div>` : ''}
+            <div class="talk-links">${links.join(' | ')}</div>`;
+          pastCards.appendChild(div);
+        });
+      }
+    })
+    .catch(err => console.error('Error loading talks', err));
 });

--- a/_talks/2025-06-19-amin.md
+++ b/_talks/2025-06-19-amin.md
@@ -21,4 +21,6 @@ abstract: >
   for such dark matter, and novel connections to "spinor” Bose-Einstein
   Condensates in the laboratory.
 speaker_photo: "https://profiles.rice.edu/sites/g/files/bxs3881/files/2020-08/Mustafa-Amin_300.jpg"
+youtube_url: "https://www.youtube.com/watch?v=Rs_OOBw4Bwo"
+slides_url: "https://drive.google.com/file/d/1pKd2Qlv3BVs6hNjIkUXN8QvL_rt4Eniw/view?usp=sharing"
 ---

--- a/about.md
+++ b/about.md
@@ -6,3 +6,8 @@ title: "About"
 ## About Merul Badda Talks
 
 The Merul Badda Talks in Maths and Physics is a seminar series hosted by the School of Data and Sciences at BRAC University.
+
+## Media Coverage
+
+- ["ব্র্যাক বিশ্ববিদ্যালয়ে ডার্ক ম্যাটার নিয়ে সেমিনার" - Prothom Alo](https://www.prothomalo.com/technology/lbd7xgnfqj)
+- ["MNS initiates a series of talks, aiming to enrich the research culture in Bangladesh" - BRACU Express](https://bracuexpress.com/mns-initiates-a-series-of-talks-aiming-to-enrich-the-research-culture-in-bangladesh/)

--- a/talks.json
+++ b/talks.json
@@ -1,0 +1,20 @@
+---
+layout: null
+---
+[
+{% assign talks = site.talks | sort: 'date' %}
+{% for talk in talks %}
+  {
+    "title": {{ talk.title | jsonify }},
+    "date": "{{ talk.date }}",
+    "speaker": {{ talk.speaker | jsonify }},
+    "affiliation": {{ talk.affiliation | jsonify }},
+    "room": {{ talk.room | jsonify }},
+    "time": {{ talk.time | jsonify }},
+    "rsvp": {{ talk.rsvp | jsonify }},
+    "youtube_url": {{ talk.youtube_url | jsonify }},
+    "slides_url": {{ talk.slides_url | jsonify }},
+    "url": "{{ talk.url | relative_url }}"
+  }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+]

--- a/upcoming.md
+++ b/upcoming.md
@@ -5,7 +5,7 @@ permalink: /upcoming/
 ---
 
 <h2 class="page-title">Upcoming Talks</h2>
-<ul>
+<ul class="upcoming-list">
   {% assign upcoming = site.talks | where_exp: 'talk', 'talk.date > site.time' | sort: 'date' %}
   {% for talk in upcoming %}
 


### PR DESCRIPTION
## Summary
- include article titles alongside outlet names in About page's Media Coverage section
- add video/slides links for Mustafa Amin talk
- serve talk data via JSON for dynamic updates and automatic move of past talks
- fix past/upcoming calculation to shift talks after the day ends

## Testing
- `npm run build` *(fails: jekyll missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855638535c8832ebcd2fd95cd7ad3bb