### PR TITLE
Add Mishaal Hai talk

### DIFF
--- a/_talks/2025-06-26-hai.md
+++ b/_talks/2025-06-26-hai.md
@@ -1,0 +1,12 @@
+---
+title: "Perturbative Kähler Moduli Inflation"
+date: 2025-06-26
+speaker: "Mishaal Hai"
+affiliation: "MSc, University of Bologna"
+room: "09C-16T"
+time: "5pm"
+rsvp: "https://forms.gle/oeJrWmggydyjEPX97"
+abstract: >
+  Inflation has been the leading candidate to describe early-universe dynamics, quelling the problems that the original Hot Big Bang model could not address (i.e., flatness, CMB isotropy, etc.). Not only did it resolve such issues, but it also put forth many novel, testable predictions. Elegant as the theory is, it remains mired in UV completion problems, necessitating a UV-complete high-energy framework. For this reason, we address inflation and present two classes of inflationary models in the framework of type IIB string theory. The inflatons correspond to blow-up Kähler moduli arising from compactifying type IIB on a Calabi-Yau manifold. Using perturbative corrections, we first highlight a procedure for stabilizing more than one Kähler modulus. For the case of two Kähler moduli, we explicitly construct two classes of inflationary potentials within the Kähler cone that satisfy both EFT and cosmological constraints.
+speaker_photo: "/assets/images/speakers/hai.jpg"
+---

--- a/assets/images/speakers/hai.jpg
+++ b/assets/images/speakers/hai.jpg
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- add Mishaal Hai talk for 26 June 2025
- include placeholder speaker photo

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler couldn't download gems)*

------
https://chatgpt.com/codex/tasks/task_e_6858b386dc9c832e8cc424239f6fea1e