### PR TITLE
Fix math rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,3 +36,7 @@ permalink: pretty
 future: true
 
 
+markdown: kramdown
+kramdown:
+  input: GFM
+  math_engine: mathjax


### PR DESCRIPTION
## Summary
- ensure kramdown uses MathJax

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686129d0f65c832e9c582039b1eb5a17