### PR TITLE
Enable MathJax rendering with example

### DIFF
--- a/_merulbadda/layouts/default.html
+++ b/_merulbadda/layouts/default.html
@@ -11,6 +11,7 @@
     <link rel="icon" href="{{ '/assets/images/favicon.ico' | relative_url }}" type="image/x-icon">
 
     <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+    <!-- MathJax configuration -->
     <script>
       window.MathJax = {
         tex: {
@@ -19,7 +20,7 @@
         }
       };
     </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
   </head>
   <body>
     {% include header.html %}

--- a/math-demo.md
+++ b/math-demo.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: "MathJax Demo"
+---
+
+This page demonstrates inline math like \(a^2 + b^2 = c^2\) within text.
+
+And here is display math:
+
+\[
+\int_{0}^{\infty} e^{-x^2} \, dx = \frac{\sqrt{\pi}}{2}
+\]
+
+You can also use $$E=mc^2$$ style notation.


### PR DESCRIPTION
## Summary
- configure MathJax in the default layout
- add a demo page showing inline and display math

## Testing
- `bundle exec jekyll build --destination _site` *(fails: `bundler: command not found: jekyll`)*

------
https://chatgpt.com/codex/tasks/task_e_68612cae7748832e807f7ab5821b1754