### PR TITLE
Fix LaTeX formatting in talk pages

### DIFF
--- a/_talks/2025-02-27-jim.md
+++ b/_talks/2025-02-27-jim.md
@@ -5,7 +5,7 @@ speaker: "Md. Rafsanjany Jim"
 affiliation: "Lecturer of Mathematics, BRAC University"
 room: "201"
 rsvp: "https://example.com/rsvp?date=2025-02-27"
-abstract: >
+abstract: |
   Noncommutative geometry and deformation quantization provide a powerful framework for extending classical geometry to quantum settings. In this talk, I will talk about a gauge invariant mathematical formalism based on deformation quantization to model an $\mathcal{N}=2$ supersymmetric system of a spin $1/2$ charged particle placed in a noncommutative plane under the influence of a vertical uniform magnetic field. The talk is based on a research paper where the noncommutative involutive algebra $(C^{\infty}(\mathbb{R}^{2})[[\vartheta]],*^r)$ of formal power series in $\vartheta$ with coefficients in the commutative ring $C^{\infty}(\mathbb{R}^{2})$ was employed to construct the relevant observables, viz., SUSY Hamiltonian $H$, supercharge operator $Q$ and its adjoint $Q^{\dag}$ all belonging to the $2\times 2$ matrix algebra $\mathcal{M}_{2}(C^{\infty}(\mathbb{R}^{2})[[\vartheta]],*^r)$ with the help of a family of gauge-equivalent star products $*^{r}$. The energy eigenvalues of the SUSY Hamiltonian all turned out to be independent of not only the gauge parameter $r$ but also the noncommutativity parameter $\vartheta$. The nontrivial Fermionic ground state was subsequently computed associated with the zero energy which indicates that supersymmetry remains unbroken in all orders of $\vartheta$. The Witten index for the noncommutative SUSY Landau problem turns out to be $-1$ corroborating the fact that there is no broken supersymmetry for the model we are considering.
 
 youtube_url: "https://youtu.be/IUxfPmvjziI"

--- a/_talks/2025-07-03-chowdhury.md
+++ b/_talks/2025-07-03-chowdhury.md
@@ -6,18 +6,18 @@ speaker: "Syed Hasibul Hassan Chowdhury"
 affiliation: "Professor, Department of Mathematics and Natural Sciences, BRAC University"
 room: "10H-39C"
 rsvp: "https://forms.gle/rXLZoq9UZcBuzcUs5"
-abstract: >
-  We develop a unified geometric framework for formal deformation quantization of coadjoint orbits of a Lie group \( G \) with Lie algebra \( \mathfrak{g} \), in which the \emph{internal} deformation parameters themselves range over the unitary dual \( \widehat{G} \). For each coadjoint orbit \( \mathcal{O}_{\lambda_0} \subset \mathfrak{g}^* \), the dual vector space of the Lie algebra \( \mathfrak{g} \), one constructs a Fedosov-type flat connection on the analogue of the single-parameter Weyl algebra bundle
-  \[
+abstract: |
+  We develop a unified geometric framework for formal deformation quantization of coadjoint orbits of a Lie group $ G $ with Lie algebra $ \mathfrak{g} $, in which the \emph{internal} deformation parameters themselves range over the unitary dual $ \widehat{G} $. For each coadjoint orbit $ \mathcal{O}_{\lambda_0} \subset \mathfrak{g}^* $, the dual vector space of the Lie algebra $ \mathfrak{g} $, one constructs a Fedosov-type flat connection on the analogue of the single-parameter Weyl algebra bundle
+  $$
   D = \nabla - \delta + \sum_{I=1}^N \frac{1}{\lambda_I} \operatorname{ad}(r_I),
-  \]
-  where \( N = \dim G - \dim \mathcal{O}_{\lambda_0} \), and the formal variables \( \lambda = (\lambda_1, \dots, \lambda_N) \in \widehat{G} \) label transverse directions to the orbit. We call the underlying bundle a \( \mathfrak{g}[[\lambda]] \)-bundle. Imposing holonomy quantization on the \emph{compactified parameter torus} forces \( \lambda \) to lie in the discrete set of actual unitary parameters, so that the resulting star product algebra \( C^\infty(\mathcal{O}_{\lambda_0})[[\lambda]], *_\lambda \) specializes—without additional projection—to the matrix algebra of the corresponding genuine irreducible representation of \( G \).
+  $$
+  where $ N = \dim G - \dim \mathcal{O}_{\lambda_0} $, and the formal variables $ \lambda = (\lambda_1, \dots, \lambda_N) \in \widehat{G} $ label transverse directions to the orbit. We call the underlying bundle a $ \mathfrak{g}[[\lambda]] $-bundle. Imposing holonomy quantization on the \emph{compactified parameter torus} forces $ \lambda $ to lie in the discrete set of actual unitary parameters, so that the resulting star product algebra $ C^\infty(\mathcal{O}_{\lambda_0})[[\lambda]], *_\lambda $ specializes—without additional projection—to the matrix algebra of the corresponding genuine irreducible representation of $ G $.
 
   At the same time, the Fedosov twist
-  \[
+  $$
   \mathcal{F} = \exp\left( -\sum_{I=1}^N \frac{1}{\lambda_I} \operatorname{ad}(r_I) \right)
-  \]
-  deforms the coproduct of \( U(\mathfrak{g}) \) into a multiparameter quantum group \( U_\lambda(\mathfrak{g}) \), and one checks that \( C^\infty(\mathcal{O}_{\lambda_0})[[\lambda]] \) becomes a natural \( U_\lambda(\mathfrak{g}) \)-module algebra. Our construction thus marries three pillars—symplectic geometry, Hopf-algebra deformation, and exact matching to the group’s unirreps—into a single, coherent deformation-quantization picture.
+  $$
+  deforms the coproduct of $ U(\mathfrak{g}) $ into a multiparameter quantum group $ U_\lambda(\mathfrak{g}) $, and one checks that $ C^\infty(\mathcal{O}_{\lambda_0})[[\lambda]] $ becomes a natural $ U_\lambda(\mathfrak{g}) $-module algebra. Our construction thus marries three pillars—symplectic geometry, Hopf-algebra deformation, and exact matching to the group’s unirreps—into a single, coherent deformation-quantization picture.
 
 speaker_photo: "/assets/images/speakers/hasib.jpeg"
 ---


### PR DESCRIPTION
## Summary
- switch Jim talk abstract to YAML literal style
- ensure Chowdhury abstract uses `$` and `$$` for LaTeX rendering

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861390a8af0832e9391659dea4a57ff