### PR TITLE
Add talk on LLM post-training

### DIFF
--- a/_merulbadda/assets/js/main.js
+++ b/_merulbadda/assets/js/main.js
@@ -57,7 +57,11 @@ document.addEventListener('DOMContentLoaded', () => {
           const dateStr = new Date(t.date).toLocaleDateString('en-US', { year:'numeric', month:'long', day:'2-digit' });
           let html = `${dateStr} - <a href="${t.url}">${t.title}</a>`;
           if (t.time) html += ` (Time: ${t.time})`;
-          if (t.room) html += ` (Room: ${t.room})`;
+          if (t.room) {
+            html += ' (Room: ';
+            html += t.room_url ? `<a href="${t.room_url}">${t.room}</a>` : t.room;
+            html += ')';
+          }
           if (t.rsvp) html += ` <a href="${t.rsvp}">RSVP</a>`;
           li.innerHTML = html;
           upcomingList.appendChild(li);

--- a/_merulbadda/layouts/talk.html
+++ b/_merulbadda/layouts/talk.html
@@ -12,7 +12,9 @@ layout: default
       <p class="date">📅 {{ page.date | date: '%B %d, %Y' }}
         {% if page.date >= site.time %}
           {% if page.time %} | Time: {{ page.time }}{% endif %}
-          {% if page.room %} | Room: {{ page.room }}{% endif %}
+          {% if page.room %} | Room:
+            {% if page.room_url %}<a href="{{ page.room_url }}">{{ page.room }}</a>{% else %}{{ page.room }}{% endif %}
+          {% endif %}
           {% if page.rsvp %} | <a href="{{ page.rsvp }}">RSVP</a>{% endif %}
         {% endif %}
       </p>

--- a/_talks/2025-07-13-tajwar.md
+++ b/_talks/2025-07-13-tajwar.md
@@ -1,0 +1,12 @@
+---
+title: "Post-Training Large Language Models: Algorithms & Applications"
+date: 2025-07-13
+time: "9pm"
+speaker: "Fahim Tajwar"
+affiliation: "PhD Student, Machine Learning Department, Carnegie Mellon University"
+room: "Online (Zoom)"
+room_url: "https://bdren.zoom.us/j/94219577607"
+abstract: >
+  Large Language Models (LLMs) like GPT-4 have demonstrated remarkable capabilities through pre-training on vast text corpora. However, their raw outputs often fall short of the nuanced expectations of human users. In this talk, I will explore the critical role of post-training techniques in aligning LLM behavior with human preferences. We begin with an overview of LLM pre-training through next-token prediction, then investigate why this objective alone is insufficient. Drawing on insights from reinforcement learning, we delve into post-training strategies including supervised fine-tuning and preference optimization methods like RLHF and Direct Preference Optimization (DPO). I will also present our recent findings—highlighting the surprising power of on-policy, suboptimal data in preference learning—and discuss the implications for future LLM alignment research. This talk is intended for audiences interested in LLMs, alignment and post-training.
+speaker_photo: "https://tajwarfahim.github.io/images/fahim_tajwar.jpg"
+---

--- a/talks.json
+++ b/talks.json
@@ -10,6 +10,7 @@ layout: null
     "speaker": {{ talk.speaker | jsonify }},
     "affiliation": {{ talk.affiliation | jsonify }},
     "room": {{ talk.room | jsonify }},
+    "room_url": {{ talk.room_url | jsonify }},
     "time": {{ talk.time | jsonify }},
     "rsvp": {{ talk.rsvp | jsonify }},
     "youtube_url": {{ talk.youtube_url | jsonify }},


### PR DESCRIPTION
## Summary
- add upcoming talk entry for Fahim Tajwar on post-training LLMs with Zoom link
- support linking room URLs in talk pages and upcoming list

## Testing
- `bundle exec jekyll build --destination _site` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686d1f185c4c832ebfa29b18562b280c