### PR TITLE
Add recording, slides, and external link behavior

### DIFF
--- a/_talks/2025-07-13-tajwar.md
+++ b/_talks/2025-07-13-tajwar.md
@@ -9,4 +9,6 @@ room_url: "https://bdren.zoom.us/j/94219577607"
 abstract: >
   Large Language Models (LLMs) like GPT-4 have demonstrated remarkable capabilities through pre-training on vast text corpora. However, their raw outputs often fall short of the nuanced expectations of human users. In this talk, I will explore the critical role of post-training techniques in aligning LLM behavior with human preferences. We begin with an overview of LLM pre-training through next-token prediction, then investigate why this objective alone is insufficient. Drawing on insights from reinforcement learning, we delve into post-training strategies including supervised fine-tuning and preference optimization methods like RLHF and Direct Preference Optimization (DPO). I will also present our recent findings—highlighting the surprising power of on-policy, suboptimal data in preference learning—and discuss the implications for future LLM alignment research. This talk is intended for audiences interested in LLMs, alignment and post-training.
 speaker_photo: "https://tajwarfahim.github.io/images/fahim_tajwar.jpg"
+youtube_url: "https://youtu.be/gYIxKwLQyAU"
+slides_url: "https://drive.google.com/file/d/15FZjF7aL4Qeo-cfTGtg373f-UfyXzgYP/view?usp=sharing"
 ---

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -33,4 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
       nav.classList.toggle('open');
     });
   }
+
+  document.querySelectorAll('a[href^="http"]').forEach(anchor => {
+    if (!anchor.href.startsWith(window.location.origin)) {
+      anchor.setAttribute('target', '_blank');
+      anchor.setAttribute('rel', 'noopener');
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- add recording and slides links for Fahim Tajwar talk
- open external links in new tab via JavaScript

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler cannot install gems due to forbidden network access)*

------
https://chatgpt.com/codex/tasks/task_e_6873deedf5dc832e98efff7513cf4d44