### PR TITLE
Add lecture series section and upcoming lectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ _merulbadda/         Jekyll layouts, includes, and assets
   assets/
 _posts/              Optional blog posts
 _talks/              Markdown files for each talk
+_lectures/           Markdown files for each lecture series entry
 about.md
 upcoming.md
 index.html
@@ -41,6 +42,29 @@ slides_url: "https://drive.google.com/file/d/ID/view"
 
 3. Provide a Google Drive link in `slides_url` for any slides.
 4. Commit the file and images to the repository.
+
+## Adding a New Lecture Series Entry
+
+1. Create a markdown file in the `_lectures/` directory named `YYYY-MM-DD-slug.md`.
+2. Use the following front matter template:
+
+```yaml
+---
+title: "Lecture title"
+date: YYYY-MM-DD
+speaker: "Speaker name"
+affiliation: "Affiliation"
+mode: "online" # or "offline"
+rsvp: "https://example.com/rsvp"
+abstract: >
+  Full abstract text
+notes_url: "https://example.com/notes.pdf"
+recording_url: "https://www.youtube.com/watch?v=VIDEOID"
+---
+```
+
+3. Optional fields such as `speaker_photo` can be included to display an image on the lecture page.
+4. Commit the file and any related assets to the repository.
 
 ## Building Locally
 

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,9 @@ collections:
   talks:
     output: true
     permalink: /talks/:path/
+  lectures:
+    output: true
+    permalink: /lectures/:path/
 
 layouts_dir: _merulbadda/layouts
 includes_dir: _merulbadda/includes
@@ -31,6 +34,11 @@ defaults:
       type: talks
     values:
       layout: talk
+  - scope:
+      path: ""
+      type: lectures
+    values:
+      layout: lecture
 
 permalink: pretty
 future: true

--- a/_lectures/2025-09-01-sample-lecture.md
+++ b/_lectures/2025-09-01-sample-lecture.md
@@ -1,0 +1,12 @@
+---
+title: "Advanced Sample Lecture"
+date: 2025-09-01
+speaker: "Dr. Sample Speaker"
+affiliation: "Sample University"
+mode: "online"
+rsvp: "https://example.com/rsvp-sample"
+notes_url: "https://example.com/notes.pdf"
+recording_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+abstract: >
+  This sample lecture provides an overview of advanced topics in sample studies.
+---

--- a/_merulbadda/includes/header.html
+++ b/_merulbadda/includes/header.html
@@ -7,6 +7,7 @@
   <nav class="site-nav">
     <ul class="nav-list">
       <li><a href="{{ '/previous-talks/' | relative_url }}">Previous Talks</a></li>
+      <li><a href="{{ '/lecture-series/' | relative_url }}">Lecture Series</a></li>
       <li><a href="{{ '/about/' | relative_url }}">About</a></li>
       <li><a href="{{ '/contact/' | relative_url }}">Contact</a></li>
     </ul>

--- a/_merulbadda/layouts/lecture.html
+++ b/_merulbadda/layouts/lecture.html
@@ -1,0 +1,35 @@
+---
+layout: default
+---
+<article class="lecture">
+  <div class="lecture-header">
+    <div class="lecture-meta">
+      <h1>{{ page.title | markdownify }}</h1>
+      <p class="speaker">{{ page.speaker }}</p>
+      <p class="affiliation">{{ page.affiliation }}</p>
+      <p class="date">📅 {{ page.date | date: '%B %d, %Y' }}{% if page.mode %} | Mode: {{ page.mode }}{% endif %}{% if page.rsvp %} | <a href="{{ page.rsvp }}">RSVP</a>{% endif %}</p>
+    </div>
+    {% if page.speaker_photo %}
+    <img src="{{ page.speaker_photo | relative_url }}" alt="{{ page.speaker }}" class="speaker-photo" />
+    {% endif %}
+  </div>
+  <section class="abstract">
+    <h2>Abstract</h2>
+    {{ page.abstract | markdownify }}
+  </section>
+  {% if page.recording_url %}
+  {% assign embed_url = page.recording_url %}
+  {% if page.recording_url contains 'youtu.be/' %}
+    {% assign yt_id = page.recording_url | split: '/' | last %}
+    {% assign embed_url = 'https://www.youtube.com/embed/' | append: yt_id %}
+  {% elsif page.recording_url contains 'youtube.com/watch' %}
+    {% assign embed_url = page.recording_url | replace: 'watch?v=', 'embed/' %}
+  {% endif %}
+  <div class="video">
+    <iframe width="560" height="315" src="{{ embed_url }}" frameborder="0" allowfullscreen></iframe>
+  </div>
+  {% endif %}
+  {% if page.notes_url %}
+  <p class="notes"><a href="{{ page.notes_url }}">Lecture Notes</a></p>
+  {% endif %}
+</article>

--- a/index.html
+++ b/index.html
@@ -29,6 +29,31 @@ title: "Home"
   {% endif %}
 </section>
 
+{% assign upcoming_lectures = site.lectures | where_exp: 'l','l.date >= site.time' | sort: 'date' %}
+<section class="upcoming-lecture">
+  <h2>Upcoming Lecture Series</h2>
+  {% if upcoming_lectures != empty %}
+  <ul class="upcoming-list">
+    {% for lecture in upcoming_lectures %}
+    <li class="upcoming-item">
+      <span class="upcoming-date">{{ lecture.date | date: '%B %d, %Y' }}.</span>
+      <div class="upcoming-details">
+        <span class="title"><a href="{{ lecture.url | relative_url }}">{{ lecture.title }}</a></span><br>
+        <span class="speaker">{{ lecture.speaker }}</span><br>
+        <span class="affiliation">{{ lecture.affiliation }}</span><br>
+        <span class="meta">
+          {% if lecture.mode %}Mode: {{ lecture.mode }}{% endif %}
+          {% if lecture.rsvp %}{% if lecture.mode %} | {% endif %}<a href="{{ lecture.rsvp }}">RSVP</a>{% endif %}
+        </span>
+      </div>
+    </li>
+    {% endfor %}
+  </ul>
+  {% else %}
+    <p>No upcoming lecture series scheduled.</p>
+  {% endif %}
+</section>
+
 <section class="previous-talks">
   <h2>Previous Talks</h2>
   <table class="talk-table previous-talks-table">

--- a/lecture-series.md
+++ b/lecture-series.md
@@ -1,0 +1,13 @@
+---
+layout: default
+title: "Lecture Series"
+permalink: /lecture-series/
+---
+
+<h2 class="page-title">Lecture Series</h2>
+<ul class="lecture-series-list">
+  {% assign lectures = site.lectures | sort: 'date' %}
+  {% for lecture in lectures %}
+  <li>{{ lecture.date | date: '%B %d, %Y' }} - <a href="{{ lecture.url | relative_url }}">{{ lecture.title }}</a> ({{ lecture.speaker }})</li>
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- add new `lectures` collection and layout
- list lecture series and show upcoming lecture series on homepage
- include header navigation, example lecture entry, and instructions for creating new lecture pages

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `npm run build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6893e332bf58832e8065e694759721ed