### PR TITLE
Refactor lecture series handling

### DIFF
--- a/_lectures/2025-09-01-sample-lecture.md
+++ b/_lectures/2025-09-01-sample-lecture.md
@@ -1,12 +1,19 @@
 ---
-title: "Advanced Sample Lecture"
+title: "Advanced Sample Lecture Series"
 date: 2025-09-01
 speaker: "Dr. Sample Speaker"
 affiliation: "Sample University"
 mode: "online"
 rsvp: "https://example.com/rsvp-sample"
-notes_url: "https://example.com/notes.pdf"
-recording_url: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
 abstract: >
-  This sample lecture provides an overview of advanced topics in sample studies.
+  This sample lecture series provides an overview of advanced topics in sample studies.
+sessions:
+  - number: 1
+    title: "Introduction to Samples"
+    recording: "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+    notes: "https://example.com/notes-1.pdf"
+  - number: 2
+    title: "Advanced Sample Techniques"
+    recording: ""
+    notes: ""
 ---

--- a/_merulbadda/layouts/lecture.html
+++ b/_merulbadda/layouts/lecture.html
@@ -17,19 +17,40 @@ layout: default
     <h2>Abstract</h2>
     {{ page.abstract | markdownify }}
   </section>
-  {% if page.recording_url %}
-  {% assign embed_url = page.recording_url %}
-  {% if page.recording_url contains 'youtu.be/' %}
-    {% assign yt_id = page.recording_url | split: '/' | last %}
-    {% assign embed_url = 'https://www.youtube.com/embed/' | append: yt_id %}
-  {% elsif page.recording_url contains 'youtube.com/watch' %}
-    {% assign embed_url = page.recording_url | replace: 'watch?v=', 'embed/' %}
-  {% endif %}
-  <div class="video">
-    <iframe width="560" height="315" src="{{ embed_url }}" frameborder="0" allowfullscreen></iframe>
-  </div>
-  {% endif %}
-  {% if page.notes_url %}
-  <p class="notes"><a href="{{ page.notes_url }}">Lecture Notes</a></p>
+  {% if page.sessions %}
+  <section class="lecture-sessions">
+    <h2>Lecture Sessions</h2>
+    <table class="talk-table lecture-table">
+      <thead>
+        <tr><th>No.</th><th>Title</th><th>Recording</th><th>Notes</th></tr>
+      </thead>
+      <tbody>
+        {% for session in page.sessions %}
+        <tr>
+          <td data-label="No.">{{ session.number }}</td>
+          <td data-label="Title">{{ session.title }}</td>
+          <td data-label="Recording">{% if session.recording %}<a href="{{ session.recording }}">Video</a>{% else %}N/A{% endif %}</td>
+          <td data-label="Notes">{% if session.notes %}<a href="{{ session.notes }}">Notes</a>{% else %}N/A{% endif %}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </section>
+  {% else %}
+    {% if page.recording_url %}
+    {% assign embed_url = page.recording_url %}
+    {% if page.recording_url contains 'youtu.be/' %}
+      {% assign yt_id = page.recording_url | split: '/' | last %}
+      {% assign embed_url = 'https://www.youtube.com/embed/' | append: yt_id %}
+    {% elsif page.recording_url contains 'youtube.com/watch' %}
+      {% assign embed_url = page.recording_url | replace: 'watch?v=', 'embed/' %}
+    {% endif %}
+    <div class="video">
+      <iframe width="560" height="315" src="{{ embed_url }}" frameborder="0" allowfullscreen></iframe>
+    </div>
+    {% endif %}
+    {% if page.notes_url %}
+    <p class="notes"><a href="{{ page.notes_url }}">Lecture Notes</a></p>
+    {% endif %}
   {% endif %}
 </article>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@ title: "Home"
 ---
 
 {% assign upcoming = site.talks | where_exp: 't','t.date >= site.time' | sort: 'date' %}
+{% assign upcoming_lectures = site.lectures | where_exp: 'l','l.date >= site.time' | sort: 'date' %}
 <section class="upcoming-talk">
   <h2>Upcoming Talks</h2>
   {% if upcoming != empty %}
@@ -27,12 +28,9 @@ title: "Home"
   {% else %}
     <p>No upcoming talks scheduled.</p>
   {% endif %}
-</section>
 
-{% assign upcoming_lectures = site.lectures | where_exp: 'l','l.date >= site.time' | sort: 'date' %}
-<section class="upcoming-lecture">
-  <h2>Upcoming Lecture Series</h2>
   {% if upcoming_lectures != empty %}
+  <h3>Upcoming Lecture Series</h3>
   <ul class="upcoming-list">
     {% for lecture in upcoming_lectures %}
     <li class="upcoming-item">
@@ -49,8 +47,6 @@ title: "Home"
     </li>
     {% endfor %}
   </ul>
-  {% else %}
-    <p>No upcoming lecture series scheduled.</p>
   {% endif %}
 </section>
 


### PR DESCRIPTION
## Summary
- Only show lecture series on home page when upcoming and display inside Upcoming Talks box
- Present lecture series sessions in a structured table
- Update sample lecture to use new sessions format

## Testing
- `npm run build` *(fails: bundler could not find jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `gem install jekyll` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6893f96fda70832eb0338dc507cc9c3f