### PR TITLE
Rename upcoming talks section to upcoming events

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@ title: "Home"
 {% assign upcoming = site.talks | where_exp: 't','t.date >= site.time' | sort: 'date' %}
 {% assign upcoming_lectures = site.lectures | where_exp: 'l','l.date >= site.time' | sort: 'date' %}
 <section class="upcoming-talk">
-  <h2>Upcoming Talks</h2>
+  <h2>Upcoming Events</h2>
   {% if upcoming != empty %}
   <ul class="upcoming-list">
     {% for talk in upcoming %}
@@ -30,7 +30,6 @@ title: "Home"
   {% endif %}
 
   {% if upcoming_lectures != empty %}
-  <h3>Upcoming Lecture Series</h3>
   <ul class="upcoming-list">
     {% for lecture in upcoming_lectures %}
     <li class="upcoming-item">


### PR DESCRIPTION
## Summary
- Rename home page upcoming section to "Upcoming Events"
- Remove "Upcoming Lecture Series" subheading while keeping lists intact

## Testing
- `npm run build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6893fbd77298832e82a7cd8324f5190d