### PR TITLE
Render content on lecture pages

### DIFF
--- a/_merulbadda/layouts/lecture.html
+++ b/_merulbadda/layouts/lecture.html
@@ -17,6 +17,9 @@ layout: default
     <h2>Abstract</h2>
     {{ page.abstract | markdownify }}
   </section>
+  <section class="lecture-content">
+    {{ content }}
+  </section>
   {% if page.sessions %}
   <section class="lecture-sessions">
     <h2>Lecture Sessions</h2>


### PR DESCRIPTION
## Summary
- Ensure lecture pages render their main content by including a `lecture-content` section in the layout

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `npm run build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6894c7e30a48832e942b8b1661e51544