### PR TITLE
Improve lecture series mobile layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -433,6 +433,42 @@ a:hover {
     margin-right: 0.5rem;
   }
 }
+
+/* Lecture series list */
+.lecture-series-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+.lecture-series-list .lecture-item {
+  background: var(--accent-light);
+  border-left: 4px solid var(--primary);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.lecture-item .lecture-date {
+  font-weight: bold;
+}
+
+.lecture-item .lecture-title {
+  margin: 0.25rem 0;
+}
+
+.lecture-item .lecture-speaker {
+  font-size: 0.9rem;
+}
+
+@media screen and (min-width: 640px) {
+  .lecture-series-list {
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  }
+}
 /* ### START MOBILE OVERRIDES ### */
 /* Place this block at the end of your existing stylesheet: */
 

--- a/lecture-series.md
+++ b/lecture-series.md
@@ -8,6 +8,10 @@ permalink: /lecture-series/
 <ul class="lecture-series-list">
   {% assign lectures = site.lectures | sort: 'date' %}
   {% for lecture in lectures %}
-  <li>{{ lecture.date | date: '%B %d, %Y' }} - <a href="{{ lecture.url | relative_url }}">{{ lecture.title }}</a> ({{ lecture.speaker }})</li>
+  <li class="lecture-item">
+    <span class="lecture-date">{{ lecture.date | date: '%B %d, %Y' }}</span>
+    <a class="lecture-title" href="{{ lecture.url | relative_url }}">{{ lecture.title }}</a>
+    <span class="lecture-speaker">{{ lecture.speaker }}</span>
+  </li>
   {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary
- Restructure lecture series page with semantic elements for each lecture entry
- Add responsive CSS to present lecture list as cards that adapt to small screens

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0bd4d3a8832e9a1c6b65087efbbb