### PR TITLE
style: enlarge talk metadata and highlight RSVP link

### DIFF
--- a/_merulbadda/layouts/talk.html
+++ b/_merulbadda/layouts/talk.html
@@ -15,7 +15,7 @@ layout: default
           {% if page.room %} | Room:
             {% if page.room_url %}<a href="{{ page.room_url }}">{{ page.room }}</a>{% else %}{{ page.room }}{% endif %}
           {% endif %}
-          {% if page.rsvp %} | <a href="{{ page.rsvp }}">RSVP</a>{% endif %}
+            {% if page.rsvp %} | <a class="rsvp-link" href="{{ page.rsvp }}">RSVP</a>{% endif %}
         {% endif %}
       </p>
     </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -188,15 +188,23 @@ a:hover {
 }
 .talk-header .speaker {
   margin-bottom: 0.5rem;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
 }
 .talk-header .affiliation {
   margin-bottom: 0.5rem;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
 }
 .talk-header .date {
   margin-top: 0.5rem;
-  font-size: 1.25rem;
+  font-size: 1.5rem;
+}
+.talk-header .date .rsvp-link {
+  background: var(--primary);
+  color: var(--accent-light);
+  padding: 0.1rem 0.4rem;
+  border-radius: 4px;
+  font-weight: bold;
+  text-decoration: none;
 }
 
 .talk {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -387,7 +387,7 @@ a:hover {
   .talk-header .speaker,
   .talk-header .affiliation,
   .talk-header .date {
-    font-size: 0.8rem;
+    font-size: 1.2rem;
   }
 
   .talk-table th,


### PR DESCRIPTION
## Summary
- Enlarge speaker, affiliation, and schedule text on individual talk pages for better readability
- Highlight RSVP links with a styled button

## Testing
- `bundle exec jekyll build --destination _site` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68b431d40c10832e8f971bb375f11dba