### PR TITLE
Tweak talk page title and speaker photo sizing

### DIFF
--- a/_merulbadda/assets/css/style.scss
+++ b/_merulbadda/assets/css/style.scss
@@ -196,7 +196,7 @@ a:hover {
 
 .talk-header h1 {
   margin-bottom: 1rem;
-  font-size: 2.5rem;
+  font-size: 2rem;
   font-weight: bold;
 }
 
@@ -222,8 +222,8 @@ a:hover {
 
 
 .talk .speaker-photo {
-  width: 150px;
-  height: 150px;
+  width: 200px;
+  height: 200px;
   object-fit: cover;
   aspect-ratio: 1 / 1;
   border: 3px solid $primary;
@@ -398,7 +398,7 @@ a:hover {
   }
   .talk .speaker-photo {
     width: 100%;
-    max-width: 200px;
+    max-width: 250px;
     aspect-ratio: 1 / 1;
   }
   .talk-table,
@@ -409,7 +409,7 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 2rem;
+    font-size: 1.75rem;
   }
 
   .talk-header .speaker,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -183,7 +183,7 @@ a:hover {
 }
 .talk-header h1 {
   margin-bottom: 1rem;
-  font-size: 2.5rem;
+  font-size: 2rem;
   font-weight: bold;
 }
 .talk-header .speaker {
@@ -213,8 +213,8 @@ a:hover {
 }
 
 .talk .speaker-photo {
-  width: 150px;
-  height: 150px;
+  width: 200px;
+  height: 200px;
   object-fit: cover;
   aspect-ratio: 1 / 1;
   border: 3px solid var(--primary);
@@ -370,7 +370,7 @@ a:hover {
   }
   .talk .speaker-photo {
     width: 100%;
-    max-width: 200px;
+    max-width: 250px;
     aspect-ratio: 1 / 1;
   }
   .talk-table,
@@ -381,7 +381,7 @@ a:hover {
   }
 
   .talk-header h1 {
-    font-size: 2rem;
+    font-size: 1.75rem;
   }
 
   .talk-header .speaker,


### PR DESCRIPTION
## Summary
- Reduce individual talk page title size for a less dominant heading.
- Enlarge speaker photos and adjust mobile scaling.

## Testing
- `bundle install` *(fails: 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68b481bd95c4832ea9bef247923cec04