### PR TITLE
Add session speaker column to lecture layout and update string-theory seminar entry

### DIFF
--- a/_lectures/2025-02-08-string-theory-seminars.md
+++ b/_lectures/2025-02-08-string-theory-seminars.md
@@ -1,0 +1,27 @@
+---
+title: "String Theory Seminars"
+date: 2025-02-08
+speaker: "Multiple Speakers"
+affiliation: "BRAC University"
+mode: "in-person"
+abstract: >
+  A seminar series on string theory hosted at BRAC University. We will build foundational intuition and
+  mathematical tools for modern string theory, following *String Theory in a Nutshell* by Elias Kiritsis.
+
+sessions:
+  - number: 1
+    title: "History of String Theory"
+    speaker: "TBA"
+    recording: ""
+    notes: ""
+---
+
+## Seminar Overview
+This lecture series explores key ideas in string theory and the historical developments that shaped the field.
+Each session is delivered by a different speaker. The first class was held on February 8, 2025.
+
+## Reference
+The primary reference for the series is *String Theory in a Nutshell* by Elias Kiritsis.
+
+## How to Join
+If you would like to join the seminars, please email **walid.hasan@g.bracu.ac.bd**.

--- a/_merulbadda/layouts/lecture.html
+++ b/_merulbadda/layouts/lecture.html
@@ -25,13 +25,14 @@ layout: default
     <h2>Lecture Sessions</h2>
     <table class="talk-table lecture-table">
       <thead>
-        <tr><th>No.</th><th>Title</th><th>Recording</th><th>Notes</th></tr>
+        <tr><th>No.</th><th>Title</th><th>Speaker</th><th>Recording</th><th>Notes</th></tr>
       </thead>
       <tbody>
         {% for session in page.sessions %}
         <tr>
           <td data-label="No.">{{ session.number }}</td>
           <td data-label="Title">{{ session.title }}</td>
+          <td data-label="Speaker">{% if session.speaker %}{{ session.speaker }}{% elsif page.speaker %}{{ page.speaker }}{% else %}TBA{% endif %}</td>
           <td data-label="Recording">{% if session.recording %}<a href="{{ session.recording }}">Video</a>{% else %}N/A{% endif %}</td>
           <td data-label="Notes">{% if session.notes %}<a href="{{ session.notes }}">Notes</a>{% else %}N/A{% endif %}</td>
         </tr>


### PR DESCRIPTION
### Motivation
- Ensure each session row shows who delivered the talk so session tables list the speaker explicitly.
- Reflect that the string-theory seminar series is run by different speakers and allow per-session overrides.

### Description
- Update `_merulbadda/layouts/lecture.html` to add a `Speaker` column header and a per-row cell that renders `session.speaker` with a fallback to `page.speaker` and then `TBA` using Liquid conditionals.
- Update `_lectures/2025-02-08-string-theory-seminars.md` to set `speaker: "Multiple Speakers"` at the page level and add `speaker: "TBA"` for the first session entry.
- The template change preserves existing `Recording` and `Notes` columns and does not alter other layout logic.

### Testing
- Attempted site build with `bundle exec jekyll build`, which failed because `jekyll`/`bundler` are not available in the environment (build exited with command not found).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988281e28b0832ea75c0d4b92bf22a8)